### PR TITLE
dependency clang was merged back into llvm-devel

### DIFF
--- a/install-dependencies-freebsd
+++ b/install-dependencies-freebsd
@@ -5,7 +5,7 @@ echo "NOTE: This file assumes that Xorg is installed and that sudo is installed.
 echo "      Also, the user must have sudo access to properly execute this script."
 echo "Installing..."
 sudo pkg install libobjc2
-sudo pkg install clang
+sudo pkg install llvm-devel
 sudo pkg install gmake
 sudo pkg install cmake
 sudo pkg install windowmaker


### PR DESCRIPTION
Another minor change for the install-dependencies-freebsd script: the dependency 'clang' was merged back into the dependency 'llvm-devel', so we need to install 'llvm-devel' instead of 'clang'