### PR TITLE
Remove mention of `tools-buildtool`

### DIFF
--- a/clone-essential-repos-https
+++ b/clone-essential-repos-https
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PREFIX="https://github.com/gnustep/"
-FILES="tools-make libs-back libs-gui libobjc2 libs-base libs-corebase plugins-themes-WinUXTheme tools-scripts tools-buildtool libs-xcode apps-gorm plugins-session"
+FILES="tools-make libs-back libs-gui libobjc2 libs-base libs-corebase plugins-themes-WinUXTheme tools-scripts libs-xcode apps-gorm plugins-session"
 
 for file in ${FILES}
 do


### PR DESCRIPTION
Removed mention of `tools-buildtool` from the script to clone the essential repositories. `tools-buildtool` has been merged into `libs-xcode`. While leaving it in the script isn't exactly harmful, it's slightly confusing for people attempting to build the software. I `grep`'d through the source code to see if it was mentioned anywhere else, and I couldn't find any other mention.

---

According to Gregory Casamento on the mailing list (December 14):

> Please do. :).  And you’re correct.  The tool was moved into the libs-Xcode directory so that everything lives in one place.