### PR TITLE
Fix libdispatch build in clang-setup

### DIFF
--- a/clang-setup
+++ b/clang-setup
@@ -34,6 +34,7 @@ make -j${CPUS}
 ${SUDO} -E make install && ${SUDO} ldconfig
 
 if [ $ARCH != arm7l ]; then
+cd /tmp
 git clone https://github.com/apple/swift-corelibs-libdispatch.git libdispatch
 echo "======== Installing libdispatch..."
 cd /tmp/libdispatch


### PR DESCRIPTION
* I was able to determine that libdispatch was getting cloned into libobjc2/build.
* The next step to build libdisaptch in /tmp/libdisaptch was failing because of this. 
* Entering /tmp again fixes this.