### PR TITLE
Allow using non-gold linkers, fix some potential errors, and install libdispatch into /usr/GNUstep

### DIFF
--- a/clang-build
+++ b/clang-build
@@ -2,11 +2,13 @@
 
 CLANG=${1:-clang}
 CLANGPP=${2:-clang++}
+linker=${3:-ld.gold}
 
 echo "Using..."
 echo ${CLANG}
 echo ${CLANGPP}
+echo ${linker}
 echo "--"
 
-$(which bash) ./tools-scripts/compile-all "/usr/GNUstep" "${CLANG}" "${CLANGPP}"
+$(which bash) ./tools-scripts/compile-all "/usr/GNUstep" "${CLANG}" "${CLANGPP}" "${linker}"
 exit

--- a/clang-setup
+++ b/clang-setup
@@ -1,11 +1,16 @@
 #!/bin/sh
+# shellcheck disable=SC2016
 
 CLANG=${1:-clang}
 CLANGPP=${2:-clang++}
+linker=${3:-ld.gold}
+
+LD=$(which "${linker}")
+export LDFLAGS="-fuse-ld=$LD"
 
 SUDO='sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH'
 CPUS="1"
-ARCH=`uname -m`
+ARCH=$(uname -m)
 
 cd /tmp
 
@@ -21,15 +26,20 @@ ${SUDO} rm -rf /tmp/libobjc2
 git clone --recursive https://github.com/gnustep/libobjc2.git
 
 # set vars
-export CC=${CLANG}
-export CXX=${CLANGPP}
+export CC="${CLANG}"
+export CXX="${CLANGPP}"
 
 # build and install
 echo "======== Installing libobjc2..."
 cd /tmp/libobjc2
 mkdir build
 cd build
-cmake -DGNUSTEP_INSTALL_TYPE=LOCAL ../
+cmake -DGNUSTEP_INSTALL_TYPE=SYSTEM ../ \
+  -DCMAKE_C_COMPILER="${CC}" \
+  -DCMAKE_CXX_COMPILER="${CXX}" \
+  -DCMAKE_ASM_COMPILER="${CC}" \
+  -DCMAKE_LINKER="${LD}" \
+  -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
 make -j${CPUS}
 ${SUDO} -E make install && ${SUDO} ldconfig
 
@@ -41,7 +51,20 @@ cd /tmp/libdispatch
 rm -rf build
 mkdir build
 cd build
-cmake ../
+cmake ../ \
+  -DCMAKE_C_COMPILER="${CC}" \
+  -DCMAKE_CXX_COMPILER="${CXX}" \
+  -DCMAKE_ASM_COMPILER="${CC}" \
+  -DCMAKE_LINKER="${LD}" \
+  -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}" \
+  -DCMAKE_INSTALL_BINDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_TOOLS)" \
+  -DCMAKE_INSTALL_LIBDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_LIBRARIES)" \
+  -DCMAKE_INSTALL_INCLUDEDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS)" \
+  -DCMAKE_INSTALL_MANDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_DOC_MAN)" \
+  -DCMAKE_INSTALL_INFODIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_DOC_INFO)" \
+  -DCMAKE_INSTALL_DOCDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_DOC)" \
+  -DCMAKE_INSTALL_DATAROOTDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_LIBRARY)" \
+  -DTESTS=OFF
 make -j${CPUS}
 ${SUDO} -E make install && ${SUDO} ldconfig
 fi

--- a/compile-all
+++ b/compile-all
@@ -35,6 +35,11 @@ if [ "$3" != "" ]; then
    cxxcompiler="$3"
 fi
 
+if [ "$4" != "" ]; then
+  linker=$4
+fi
+
+
 # Check if we are compiling under windows...
 UNAME=`uname | cut -d'-' -f1`
 if [ "$UNAME" != "MINGW32_NT" ] ; then
@@ -75,9 +80,38 @@ else
   export CXX=$cxxcompiler
 fi
 
+if [[ "$CC" == gcc* ]]; then
+  USING_GCC=true
+else
+  USING_GCC=false
+fi
+
+if [ "$4" == "" ]; then
+  if ! $USING_GCC; then
+    linker=ld.gold
+  fi
+else
+  LD=$(which "$linker")
+  if $USING_GCC; then
+    # We must create a directory and symlink the linker into there.
+    mkdir temp_linker_dir
+    cd temp_linker_dir
+      ln -s "$LD" ./ld
+    cd ..
+    export LDFLAGS="$LDFLAGS -B$(realpath temp_linker_dir)"
+  else
+    # Clang allows constructions such as -fuse-ld=/usr/bin/ld.lld-18
+    export LDFLAGS="$LDFLAGS -fuse-ld=$LD"
+  fi
+fi
 echo "==== compile-all"
 echo "Using compiler $CC"
 echo "Using c++ compiler $CXX"
+if [ "$4" == "" ]; then
+  echo "Using default linker"
+else
+  echo "Using linker $LD"
+fi
 echo "===="
 
 # Flags for windows build.
@@ -86,7 +120,7 @@ if [ "$UNAME" == "MINGW32_NT" ] ; then
 fi
 
 # If we are building with clang, then add this to cc_flags
-if [ "$CC" != "gcc" ] ; then
+if ! $USING_GCC; then
     export cc_flags="-fblocks -fobjc-nonfragile-abi ${cc_flags}"
 fi
 
@@ -94,7 +128,7 @@ fi
 echo "Installing GNUstep into ${prefix}"
 cd tools-make
 # make distclean
-if [ "$CC" == "gcc" ]; then
+if $USING_GCC; then
     echo "==== BUILDING WITH GCC"
     echo "Build command: CCFLAGS=$cc_flags CC=$CC ./configure --prefix=${prefix} --with-library-combo=gnu-gnu-gnu --with-layout=gnustep $make_flags"
 
@@ -109,8 +143,9 @@ else
     export CC=${compiler}
     export CXX=${cxxcompiler}
     # export LDFLAGS=-ldispatch
-    export LDFLAGS=-fuse-ld=gold -ldispatch
-    echo "CCFLAGS=${cc_flags} CXX=${CXX} CC=${CC} ./configure --prefix=${prefix} --with-library-combo=ng-gnu-gnu --enable-objc-arc --enable-native-objc-exceptions --with-layout=gnustep ${make_flags}"
+    export LDFLAGS="$LDFLAGS -ldispatch"
+    echo "LDFLAGS=$LDFLAGS"
+    echo "Build command: CCFLAGS=${cc_flags} CXX=${CXX} CC=${CC} ./configure --prefix=${prefix} --with-library-combo=ng-gnu-gnu --enable-objc-arc --enable-native-objc-exceptions --with-layout=gnustep ${make_flags}"
     CCFLAGS=${cc_flags} CXX=${CXX} CC=${CC} ./configure --prefix=${prefix} --with-library-combo=ng-gnu-gnu --enable-objc-arc --enable-native-objc-exceptions --with-layout=gnustep ${make_flags}
 fi
 
@@ -125,7 +160,7 @@ fi
 . $prefix/System/Library/Makefiles/GNUstep.sh
 
 # Setup clang specific libraries...
-if [ "$CC" != "gcc" ]; then
+if ! $USING_GCC; then
     ${scriptsdir}/clang-setup "$CLANG" "$CLANGPP"
 fi
 
@@ -134,7 +169,7 @@ echo "======== Installing Base..."
 cd ../libs-base
 make distclean
 . $prefix/System/Library/Makefiles/GNUstep.sh
-$MAKE GNUSTEP_INSTALLATION_DOMAIN=SYSTEM debug=yes
+$MAKE GNUSTEP_INSTALLATION_DOMAIN=SYSTEM debug=yes || exit 1
 if [ "true" == "$NEEDSROOT" ]; then
 ${SUDO} -u root ./install.sh $prefix $MAKE
 else

--- a/install-gnustep-llvm18-debian
+++ b/install-gnustep-llvm18-debian
@@ -1,0 +1,26 @@
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+sudo apt install clang-18 clangd-18 lld-18 lldb-18 liblldb-18
+
+export KERNEL=`uname -s | sed "s/\-.*//g" | awk '{print(tolower($0))}'`
+echo "Begin setup for ${KERNEL}"
+
+# export USER=`whoami`
+# curl -fsSL > ./setup-${KERNEL} https://raw.githubusercontent.com/gnustep/tools-scripts/master/setup-${KERNEL}
+# . ./setup-${KERNEL}
+# rm ./setup-${KERNEL}
+source ./tools-scripts/setup-${KERNEL}
+
+# mkdir -p gnustep
+# cd gnustep
+# git clone https://github.com/gnustep/tools-scripts
+./tools-scripts/clone-essential-repos-https
+
+./tools-scripts/install-dependencies-${KERNEL}
+
+./tools-scripts/clang-build clang-18 clang++-18 ld.lld-18
+
+./tools-scripts/post-install-${KERNEL}
+
+echo "Done..."

--- a/post-install-linux
+++ b/post-install-linux
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 pwd
-cd apps-gorm
+cd apps-gorm || exit 1
 make debug=yes
-su -c 'make GNUSTEP_INSTALLATION_DOMAIN=SYSTEM debug=yes install'
+sudo -E make GNUSTEP_INSTALLATION_DOMAIN=SYSTEM debug=yes install
 

--- a/setup-linux
+++ b/setup-linux
@@ -13,8 +13,9 @@ else
 fi
 
 if [ ! -e /etc/sudoers.d/${USER} ]; then
-   echo "Add ${USER} to sudoers"
+   echo "Adding ${USER} to sudoers..."
+   echo "Please enter the root user's password."
    su -c 'echo "${USER}    ALL=(ALL:ALL) ALL" > /etc/sudoers.d/${USER}'
 else
-   echo "User is already a member of sudo users."
+   echo "${USER} is already a member of sudo users."
 fi


### PR DESCRIPTION
These changes allow using linkers other than `ld.gold` (the linker is specified as the last argument to most scripts), make the code a bit more consistent, and install libdispatch into `/usr/GNUstep`. Installing libdispatch into `/usr/local/lib` will cause issues on Debian-based systems, which by default completely ignore `/usr/local` when linking. Installing libdispatch into `/usr/GNUstep` would prevent conflicts with any software in `/usr` or `/usr/local` that needed a package manager-provided libdispatch (this is a theoretical concern), but also keeps the things installed by `tools-scripts` contained in `/usr/GNUstep` and allows libdispatch to be found by the linker without the user needing to edit the linker configuration.

I have only tested these changes on x86_64 Linux using Clang.