### PR TITLE
Build libobjc2 from source and install dependencies without prompting for FreeBSD

### DIFF
--- a/build-freebsd
+++ b/build-freebsd
@@ -28,19 +28,17 @@ echo "==="
 
 # Build libjobc2
 echo "======== Build libobjc2"
-cd ../libobjc2
-mkdir Build
-cd Build && pwd && ls && cmake .. \
+cd ../libobjc2 && mkdir Build && cd Build && cmake .. \
 -DGNUSTEP_INSTALL_TYPE=SYSTEM \
 -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_C_COMPILER=clang \
 -DCMAKE_CXX_COMPILER=clang++; \
-${SUDO} -u root ./install.sh ${GNUSTEP_ROOT} ${MAKE}
+${SUDO} -u root ${MAKE} install
 echo "==="
 
 # Build base
 echo "======== Build base"
-cd ../libs-base
+cd ../../libs-base
 ./configure --with-installation-domain=SYSTEM --disable-icu --disable-invocations
 LDFLAGS=${LDFLAGS} CC=${CC} CXX=${CXX} ${MAKE} debug=yes messages=no -j4
 ${SUDO} -u root ./install.sh ${GNUSTEP_ROOT} ${MAKE}

--- a/build-freebsd
+++ b/build-freebsd
@@ -28,7 +28,7 @@ echo "==="
 
 # Build libjobc2
 echo "======== Build libobjc2"
-cd ../libobjc2 && mkdir Build && cd Build && cmake .. \
+cd ../libobjc2 && [ -d Build ] && rm -rf Build && mkdir Build && cd Build && cmake .. \
 -DGNUSTEP_INSTALL_TYPE=SYSTEM \
 -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_C_COMPILER=clang \

--- a/build-freebsd
+++ b/build-freebsd
@@ -26,6 +26,18 @@ ${SUDO} -u root ${MAKE} install
 . ${GNUSTEP_ROOT}/System/Library/Makefiles/GNUstep.sh
 echo "==="
 
+# Build libjobc2
+echo "======== Build libobjc2"
+cd ../libobjc2
+mkdir Build
+cd Build && pwd && ls && cmake .. \
+-DGNUSTEP_INSTALL_TYPE=SYSTEM \
+-DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_C_COMPILER=clang \
+-DCMAKE_CXX_COMPILER=clang++; \
+${SUDO} -u root ./install.sh ${GNUSTEP_ROOT} ${MAKE}
+echo "==="
+
 # Build base
 echo "======== Build base"
 cd ../libs-base

--- a/install-dependencies-freebsd
+++ b/install-dependencies-freebsd
@@ -4,22 +4,21 @@ echo "Installing FreeBSD dependencies"
 echo "NOTE: This file assumes that Xorg is installed and that sudo is installed."
 echo "      Also, the user must have sudo access to properly execute this script."
 echo "Installing..."
-sudo pkg install libobjc2
-sudo pkg install llvm
-sudo pkg install gmake
-sudo pkg install cmake
-sudo pkg install windowmaker
-sudo pkg install openjpeg
-sudo pkg install tiff
-sudo pkg install png
-sudo pkg install libxml2
-sudo pkg install libxslt
-sudo pkg install gnutls
-sudo pkg install libffi
-sudo pkg install icu
-sudo pkg install cairo
-sudo pkg install avahi
-sudo pkg install portaudio
-sudo pkg install flite
+sudo pkg install -y llvm
+sudo pkg install -y gmake
+sudo pkg install -y cmake
+sudo pkg install -y windowmaker
+sudo pkg install -y openjpeg
+sudo pkg install -y tiff
+sudo pkg install -y png
+sudo pkg install -y libxml2
+sudo pkg install -y libxslt
+sudo pkg install -y gnutls
+sudo pkg install -y libffi
+sudo pkg install -y icu
+sudo pkg install -y cairo
+sudo pkg install -y avahi
+sudo pkg install -y portaudio
+sudo pkg install -y flite
 echo "Done..."
 exit 0


### PR DESCRIPTION
* This changes behavior to install packages without prompting when using ./install-dependencies-freebsd.
* For FreeBSD Installing libobjc2 from package will remove libdispatch if installed and this fixes part of that issue.
* For Linux libobjc2 is also build from sources so this modifies behavior to be more of the same.