### PR TITLE
Adding some additional packages for building with wayland

### DIFF
--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -42,6 +42,8 @@ install_debian()
     sudo apt --yes install sphinxtrain
     sudo apt --yes install libssl-dev
     sudo apt --yes install freeglut3-dev
+    sudo apt --yes install libxwayland-dev
+    sudo apt --yes install libxkbcommon-dev
     
     echo "-------"
     echo "Done..."

--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -44,6 +44,7 @@ install_debian()
     sudo apt --yes install freeglut3-dev
     sudo apt --yes install libwayland-dev
     sudo apt --yes install libxkbcommon-dev
+    sudo apt --yes install wayland-protocols
     
     echo "-------"
     echo "Done..."

--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -42,7 +42,7 @@ install_debian()
     sudo apt --yes install sphinxtrain
     sudo apt --yes install libssl-dev
     sudo apt --yes install freeglut3-dev
-    sudo apt --yes install libxwayland-dev
+    sudo apt --yes install libwayland-dev
     sudo apt --yes install libxkbcommon-dev
     
     echo "-------"


### PR DESCRIPTION
This adds packages that are needed when compiling the GNUstep libs-back library with Wayland support (./configure --enable-server=wayland) on Debian.