### PR TITLE
Some tiny OpenBSD related enhancements

### DIFF
--- a/clone-all-repos
+++ b/clone-all-repos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PREFIX="git@github.com:gnustep/"
 FILES="libs-back libs-gui apps-projectcenter libs-palettes libs-boron apps-easydiff libs-opal libs-ec libs-mica libs-webservices libobjc2 libs-performance libs-base libs-sqlclient libs-corebase libs-dbuskit gitsvn-scripts plugins-themes-WinUXTheme plugins-themes-Gtk plugins-session plugins-gs-emacs libs-gscoredata apps-thematic apps-systempreferences tools-android android-examples tools-windows-development-installer tools-startup libs-gsweb tools-nfmake tools-installers tests-testsuite tests-retaincount tests-palettetest tests-gormtest libs-webserver libs-uikit libs-ucsdata libs-sysconfig apps-interfacecreator tests-examples libs-xcode libs-steptalk libs-smbkit libs-simplewebkit libs-ruby libs-renaissance libs-quartzcore libs-ppd libs-java libs-guile libs-gsldap libs-gsgd libs-gscrypt libs-gsantlr libs-gdl2 libs-corenetwork libs-coreimage gap libs-audiotoolbox apps-gworkspace apps-gsldapwebexplorer apps-gorm tools-make tools-scripts tools-model-main tools-charsets plugins-deprecated license libobjc webkit-cef apps-dock tools-bridge plugins-themes tools-windows-msvc"

--- a/install-dependencies-openbsd
+++ b/install-dependencies-openbsd
@@ -1,26 +1,14 @@
 #!/bin/sh
 
+# change to doas if you use doas
+SUDO=sudo
+GCC_MAJOR=11
+
 echo "Installing OpenBSD dependencies"
 echo "NOTE: This file assumes that Xorg is installed and that sudo is installed."
-echo "      Also, the user must have sudo access to properly execute this script."
+echo "      Change the SUDO= variable at top of script to use 'doas' instead"
+echo "      Also, 'doas' or 'sudo' should be properly configured to allow running the script."
 echo "Installing..."
-sudo pkg_add gmake
-sudo pkg_add cmake
-sudo pkg_add windowmaker
-sudo pkg_add jpeg
-sudo pkg_add tiff
-sudo pkg_add png
-sudo pkg_add libxml
-sudo pkg_add libxslt
-sudo pkg_add gnutls
-sudo pkg_add libffi
-sudo pkg_add icu4c
-sudo pkg_add cairo
-sudo pkg_add avahi
-sudo pkg_add gcc
-sudo pkg_add gobjc
-sudo pkg_add gdb
-sudo pkg_add gnustep-libobjc2
-sudo pkg_add flite
+${SUDO} pkg_add curl git sudo-- gmake cmake windowmaker jpeg tiff png libxml gnutls libffi icu4c cairo avahi gcc%${GCC_MAJOR} gobjc%${GCC_MAJOR} gmp gdb gnustep-libobjc2 flite
 echo "Done..."
 exit 0

--- a/setup-openbsd
+++ b/setup-openbsd
@@ -5,12 +5,11 @@ echo "=== Setup OpenBSD"
 if [ ! -e /usr/local/bin/sudo ]; then
     echo "Installing sudo"
     echo "Enter root password"
-    su -m root -c 'pkg_add sudo'
-    if [ ! -e /etc/sudoers ]; then
-	echo "Add ${USER} to sudoers"
-	echo "Enter root password"
-	su -m root -c 'echo "${USER}    ALL=(ALL) SETENV: ALL" >> /etc/sudoers'
-    fi
+    su -m root -c 'pkg_add sudo--'
+    
+    echo "Add ${USER} to sudoers"
+    echo "Enter root password"
+    su -m root -c 'echo "${USER}    ALL=(ALL) SETENV: ALL" >> /etc/sudoers'
 fi
 
 # Make sure git is installed


### PR DESCRIPTION
 * install-dependencies-openbsd
   * make it faster, just use a single pkg_add and prevent it from asking which versions to install
 * setup-openbsd
   * when installing sudo package, /etc/sudoers will exist, so just ALWAYS append line to that file
     * this is not idempotent, but a shell script is also not a proper configuration management ;)

install-dependencies-openbsd