### PR TITLE
Modifications for Slackware support

### DIFF
--- a/clang-setup
+++ b/clang-setup
@@ -66,6 +66,7 @@ cmake ../ \
   -DCMAKE_INSTALL_DATAROOTDIR="$(gnustep-config --variable=GNUSTEP_SYSTEM_LIBRARY)" \
   -DTESTS=OFF
 make -j${CPUS}
+echo "$(gnustep-config  --variable=GNUSTEP_SYSTEM_LIBRARIES)" | sudo tee -a /etc/ld.so.conf.d/GNUstep.conf > /dev/null
 ${SUDO} -E make install && ${SUDO} ldconfig
 fi
 

--- a/gnustep-web-install
+++ b/gnustep-web-install
@@ -45,7 +45,7 @@ git clone https://github.com/gnustep/tools-scripts
 
 echo "================ Install Dependencies ================"
 # Install dependencies
-./tools-scripts/install-dependencies-${KERNEL}
+./tools-scripts/install-dependencies-${KERNEL} || exit 1
 
 echo "================ Build ================"
 # Build it...

--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -107,6 +107,11 @@ get_system()
 get_system
 echo "You are using ${ID}"
 
+if [[ ${ID} == "slackware" ]]; then
+	./tools-scripts/install-dependencies-slackware || exit 1
+    exit	
+fi
+
 which apt > /dev/null
 if [ "$?" == "0" ]; then
     install_debian

--- a/install-dependencies-slackware
+++ b/install-dependencies-slackware
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+
+. /etc/os-release 
+version=${VERSION//[\.]/-}
+
+echo
+echo "The Slackware dependency relies on you (the user currently running gnustep-web-install) be part of the sudoers."
+echo "Also, you need to have slackpkg setup and configured to allow the script to resolve any missing dependencies."
+echo "If you are not currently a sudoer or do not have slackpkg setup, please exit here and configure these two items."
+echo
+read -p "Continue with the procedure? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+echo
+
+echo "GNUstep / Slackware ${VERSION} dependency installation"
+echo "------------------------------------------------"
+echo
+
+
+if [[ "$version" != "15-0" ]]; then
+	echo "Only Slackware version 15.0 is supported at the moment"
+	exit
+fi
+
+# check if slackpkg is setup (a mirror has been chosen)
+
+mirror=$(grep -v '^#' /etc/slackpkg/mirrors)
+
+if [[ -z ${mirror} ]]; then
+	echo "slackpkg not setup"
+	exit 1
+else
+	echo "slackpkg mirror set to:"
+	echo
+   	echo "${mirror}"
+	echo
+	echo "We'll use that to install missing packages (if any)"
+	echo
+fi
+
+
+# s l a c k w a r e  15 package dependencies
+declare -A packages[15-0]="gcc gcc-objc llvm libjpeg-turbo libtiff libpng libxml2 libxslt "
+packages[15-0]+="gdb gnutls libffi icu4c cairo make makedepend windowmaker cmake "
+packages[15-0]+="libblockdev openssl openssl-solibs imagemagick "
+packages[15-0]+="libxkbcommon wayland freetype-2 "
+
+
+
+# because we want to cycle through the dependency list based on the slackware version, required a
+# slighlty more complex for loop using the array index and indirection (the ! before packages below is indirection)
+for pkg in ${packages["${version}"]}; do
+	if [[ -n $(find /var/log/packages/${pkg}*) ]]; then
+		printf 'Looking for package %-15s: %s\n' "$pkg" "found"
+	else
+		echo "Trying to install missing pkg ${pkg}"
+		sudo /usr/sbin/slackpkg install ${pkg}
+	fi
+done 
+
+echo
+echo "Slackware dependencies resolved, have fun!"
+
+
+

--- a/post-install-linux
+++ b/post-install-linux
@@ -1,7 +1,18 @@
 #!/bin/sh
+# we have a new path
+export PATH=$PATH:/usr/GNUstep/System/Tools
 
-pwd
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
 cd apps-gorm || exit 1
 make debug=yes
 sudo -E make GNUSTEP_INSTALLATION_DOMAIN=SYSTEM debug=yes install
 
+echo
+echo "GNUstep web install complete. You will need to source in this file into your shell using this command (the leading . is required):"
+echo
+echo ". /usr/GNUstep/System/Library/Makefiles/GNUstep.sh"
+echo
+
+echo "Please add this to your ~/.bash_profile (or your shell's equivalent) so the GNUstep environment is always set."
+echo "Welcome to GNUstep!"

--- a/setup-linux
+++ b/setup-linux
@@ -4,7 +4,11 @@ export USER=`whoami`
 COMMAND="apt"
 
 # Add distro specific variables...
-. /etc/lsb-release
+if [[ -f /etc/lsb-release ]]; then
+	. /etc/lsb-release
+elif [[ -f /etc/os-release ]]; then
+	. /etc/os-release
+fi
 
 # Install SUDO if needed...
 if [ ! -e /usr/bin/sudo ]; then
@@ -29,15 +33,18 @@ if [ "${DISTRIB_ID}" = "Ubuntu" ]; then
    fi
 fi
 
-# Add to sudoers
-if [ "${DISTRIB_ID}" != "Ubuntu" ]; then
-   if [ ! -e /etc/sudoers.d/${USER} ]; then
-      echo "Adding ${USER} to sudoers..."
-      echo "Please enter the root user's password."
-      su -c 'echo "${USER}    ALL=(ALL:ALL) ALL" > /etc/sudoers.d/${USER}'
-   else
-      echo "${USER} is already a member of sudo users."
-   fi
+# Add to sudoers. slackware dependency install will prompt user to set it up
+# prior to completing the gnustep-web-install 
+if [ "${ID}" != "slackware" ]; then
+  if [ "${DISTRIB_ID}" != "Ubuntu" ]; then
+     if [ ! -e /etc/sudoers.d/${USER} ]; then
+        echo "Adding ${USER} to sudoers..."
+        echo "Please enter the root user's password."
+        su -c 'echo "${USER}    ALL=(ALL:ALL) ALL" > /etc/sudoers.d/${USER}'
+     else
+        echo "${USER} is already a member of sudo users."
+     fi
+  fi
 fi
 
 # Install git and curl if needed...


### PR DESCRIPTION
Various changes to add Slackware 15.0 support to the gnustep-web-install procedure. The process requires the user to be setup in sudoers and will attempt to resolve any missing dependencies using slackpkg.

This is my first pull request, if any issues please let me know.