### PR TITLE
Add base script description to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,53 @@ The purposes of all of the scripts is as follows:
 
 
 
+Install GNUstep environment in one go
+===
+
+The main script `gnustep-web-install` is a bit lighter than the `gnustep-web-install-dev`
+script described later. It is _still_ making a _lot_ of assumptions about your machine
+being reasonably clean, and it may change your setup in an unexpected way. You're recommended
+to run it on an empty machine you're happy to reinstall later: other use of this one-step
+script is not recommended at this time.
+
+The main difference is that it will not expect you to have SSH set up with private keys
+known to GitHub.
+
+Assume an empty development VM, i.e. Linux, OpenBSD, you name it:
+
+```
+mkdir ~/gnustep
+cd ~/gnustep
+```
+
+with curl already installed:
+```
+curl -fsSL > gnustep-web-install https://raw.githubusercontent.com/gnustep/tools-scripts/refs/heads/master/gnustep-web-install
+```
+or on OpenBSD with ftp:
+```
+ftp -o gnustep-web-install https://raw.githubusercontent.com/gnustep/tools-scripts/refs/heads/master/gnustep-web-install
+```
+
+Review what the script is doing, and you may visit the other scripts it's fetching and installing. Once you're confident, it's good to go:
+
+If you're on OpenBSD, the default invocation of ./gnustep-web-install will build with gcc against gcc libobjc.
+If you want to build against libobjc2 with ARC support, before going on export WITH_ARC=yes environment variable.
+
+```
+chmod 755 gnustep-web-install
+./gnustep-web-install
+```
+
+Go grab a coffee, and wait a bit.
+
+Once it finished, source GNUstep.sh and start developing:
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+
+Please report any bugs you find with this set of scripts.
+
 Install GNUstep dev environment
 ===
 


### PR DESCRIPTION
This adds instructions for installing the GNUstep environment using the simpler / main script `gnustep-web-install`.

Even though the base script is also somewhat developer oriented, the `-dev` script is really tailored towards developers by installing a lot more of the system stack, and by expecting ssh-based Git URIs to actually work (i.e. to have SSH private keys set up with GitHub).
