### PR TITLE
Added missing "fi" causing "unexpected end of file" error

### DIFF
--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -171,5 +171,5 @@ else
             echo "Please report this to bugs-gnustep@gnu.org."
             echo "Your linux os ${ID} is currently unsupported."
         fi
+    fi
 fi
-


### PR DESCRIPTION
Hi!

I tried setting up a gnustep dev environment using the web install script on Fedora Linux 42, but it threw a `Syntax Error: unexpected end of file` error when executing `install-dependencies-linux`. There seems to be missing a closing `fi` at the end if I'm not mistaken? 

After adding it, the installer completes successfully and the installed dev environment appears to be working fine on Fedora! :blush:   