### PR TITLE
Fix a syntax error in install-dependencies-linux.

### DIFF
--- a/install-dependencies-linux
+++ b/install-dependencies-linux
@@ -171,5 +171,6 @@ else
             echo "Please report this to bugs-gnustep@gnu.org."
             echo "Your linux os ${ID} is currently unsupported."
         fi
+    fi
 fi
 


### PR DESCRIPTION
Commit 0be21a799017242b9484b1ba79d9bcb8d5fd8c5b introduced a syntax error with an unbalanced `if`/`fi` blocks at lines 173-174.